### PR TITLE
Update to add preview link

### DIFF
--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netlify-cms-core",
   "description": "Netlify CMS core application, see netlify-cms package for the main distribution.",
-  "version": "2.9.0",
+  "version": "2.9.0-fac",
   "repository": "https://github.com/netlify/netlify-cms/tree/master/packages/netlify-cms-core",
   "bugs": "https://github.com/netlify/netlify-cms/issues",
   "main": "dist/netlify-cms-core.js",

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -146,6 +146,18 @@ class EditorInterface extends Component {
     localStorage.setItem(SCROLL_SYNC_ENABLED, newScrollSyncEnabled);
   };
 
+  previewLink = (entry) => {
+    let previewUrl
+    if (!!entry.get('metaData') && !!entry.getIn(['metaData', 'pr'])) {
+      let branch = entry.getIn(['metaData', 'branch']).substring(0,51).replace("/", "--");
+      let prNumber = entry.getIn(['metaData', 'pr', 'number']);
+      previewUrl = "http://" + prNumber + "---" + branch + ".preview.www.fre.ag";
+    } else {
+      previewUrl = "http://preview.www.fre.ag";
+    };
+    return previewUrl;
+  };
+
   render() {
     const {
       collection,
@@ -224,6 +236,7 @@ class EditorInterface extends Component {
           isPersisting={entry.get('isPersisting')}
           isPublishing={entry.get('isPublishing')}
           isUpdatingStatus={entry.get('isUpdatingStatus')}
+          previewLink={this.previewLink(entry)}
           isDeleting={entry.get('isDeleting')}
           onPersist={this.handleOnPersist}
           onPersistAndNew={() => this.handleOnPersist({ createNew: true })}

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -141,6 +141,14 @@ const SaveButton = styled(ToolbarButton)`
   ${buttons.lightBlue};
 `;
 
+const WebsitePreviewLink = styled.a`
+  ${styles.buttonMargin};
+  ${buttons.button};
+  ${buttons.default};
+  color: ${colorsRaw.teal};
+  background-color: ${colorsRaw.tealLight};
+`;
+
 const StatusPublished = styled.div`
   ${styles.buttonMargin};
   border: 1px solid ${colors.textFieldBorder};
@@ -204,6 +212,7 @@ class EditorToolbar extends React.Component {
     isPersisting: PropTypes.bool,
     isPublishing: PropTypes.bool,
     isUpdatingStatus: PropTypes.bool,
+    previewLink: PropTypes.string,
     isDeleting: PropTypes.bool,
     onPersist: PropTypes.func.isRequired,
     onPersistAndNew: PropTypes.func.isRequired,
@@ -373,6 +382,8 @@ class EditorToolbar extends React.Component {
     const {
       collection,
       isUpdatingStatus,
+      previewLink,
+      hasUnpublishedChanges,
       isPublishing,
       onChangeStatus,
       onPublish,
@@ -384,6 +395,9 @@ class EditorToolbar extends React.Component {
     if (currentStatus) {
       return (
         <>
+          {hasUnpublishedChanges ? (
+            <WebsitePreviewLink href={previewLink}>Website Preview</WebsitePreviewLink>
+          ) : null}
           {this.renderDeployPreviewControls(t('editor.editorToolbar.deployPreviewButtonLabel'))}
           <ToolbarDropdown
             dropdownTopOverlap="40px"

--- a/packages/netlify-cms/package.json
+++ b/packages/netlify-cms/package.json
@@ -1,7 +1,7 @@
 {
   "name": "netlify-cms",
   "description": "An extensible, open source, Git-based, React CMS for static sites.",
-  "version": "2.7.0",
+  "version": "2.7.0-fac",
   "homepage": "https://www.netlifycms.org",
   "repository": "https://github.com/netlify/netlify-cms",
   "bugs": "https://github.com/netlify/netlify-cms/issues",
@@ -32,7 +32,7 @@
     "netlify-cms-backend-github": "^2.3.0",
     "netlify-cms-backend-gitlab": "^2.2.0",
     "netlify-cms-backend-test": "^2.1.0",
-    "netlify-cms-core": "^2.9.0",
+    "netlify-cms-core": "git+ssh://git@github.com/fac/netlify-cms.git#netlify-cms-core-v2.9.0-fac-gitpkg",
     "netlify-cms-editor-component-image": "^2.3.0",
     "netlify-cms-media-library-cloudinary": "^1.2.0",
     "netlify-cms-media-library-uploadcare": "^0.4.0",


### PR DESCRIPTION
Adds the website preview link into the master version of netlify-cms at verson 2.7.0.